### PR TITLE
Time logging for monitor job run

### DIFF
--- a/src/main/java/com/appdynamics/extensions/ABaseMonitor.java
+++ b/src/main/java/com/appdynamics/extensions/ABaseMonitor.java
@@ -21,6 +21,7 @@ import com.appdynamics.extensions.file.FileWatchListener;
 import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
 import com.appdynamics.extensions.util.AssertUtils;
 import com.appdynamics.extensions.util.PathResolver;
+import com.appdynamics.extensions.util.TimeUtils;
 import com.singularity.ee.agent.systemagent.api.AManagedMonitor;
 import com.singularity.ee.agent.systemagent.api.TaskExecutionContext;
 import com.singularity.ee.agent.systemagent.api.TaskOutput;
@@ -85,6 +86,7 @@ public abstract class ABaseMonitor extends AManagedMonitor {
 
     private static final Logger logger = ExtensionsLoggerFactory.getLogger(ABaseMonitor.class);
 
+    private Long startTime;
     /**
      * The name of the monitor.
      */
@@ -174,6 +176,8 @@ public abstract class ABaseMonitor extends AManagedMonitor {
      */
     @Override
     public TaskOutput execute(Map<String, String> args, TaskExecutionContext taskExecutionContext) throws TaskExecutionException {
+        startTime = System.currentTimeMillis();
+        logger.info("Started executing " + monitorName + " at " + TimeUtils.getFormattedTimestamp(startTime, "yyyy-MM-dd HH:mm:ss z"));
         logger.info("Using {} Version [" + getImplementationVersion() + "]", monitorName);
         logger.debug("The raw arguments are {}", args);
         initialize(args);
@@ -198,6 +202,10 @@ public abstract class ABaseMonitor extends AManagedMonitor {
 
     protected static String getImplementationVersion() {
         return ABaseMonitor.class.getPackage().getImplementationTitle();
+    }
+
+    public Long getStartTime() {
+        return startTime;
     }
 
     protected abstract String getDefaultMetricPrefix();

--- a/src/main/java/com/appdynamics/extensions/MetricWriteHelper.java
+++ b/src/main/java/com/appdynamics/extensions/MetricWriteHelper.java
@@ -25,6 +25,7 @@ import com.appdynamics.extensions.metrics.derived.DerivedMetricsCalculator;
 import com.appdynamics.extensions.metrics.transformers.Transformer;
 import com.appdynamics.extensions.util.AssertUtils;
 import com.appdynamics.extensions.util.MetricPathUtils;
+import com.appdynamics.extensions.util.TimeUtils;
 import com.google.common.collect.Maps;
 import com.singularity.ee.agent.systemagent.api.MetricWriter;
 import org.slf4j.Logger;
@@ -41,10 +42,14 @@ public class MetricWriteHelper {
     public static final Logger logger = ExtensionsLoggerFactory.getLogger(MetricWriteHelper.class);
 
     private ABaseMonitor baseMonitor;
+
+    private Long startTime;
+
     //Used for Dashboard. Cache the current list of metrics.
     private boolean cacheMetrics;
 
     protected DerivedMetricsCalculator derivedMetricsCalculator;
+
     private Map<String, String> metricsMap = Maps.newConcurrentMap();
 
     //used from WorkBench.
@@ -54,6 +59,7 @@ public class MetricWriteHelper {
     public MetricWriteHelper(ABaseMonitor baseMonitor) {
         AssertUtils.assertNotNull(baseMonitor, "The ABaseMonitor instance cannot be null");
         this.baseMonitor = baseMonitor;
+        this.startTime = this.baseMonitor.getStartTime();
         derivedMetricsCalculator = baseMonitor.getContextConfiguration().getContext().createDerivedMetricsCalculator();
     }
 
@@ -127,19 +133,48 @@ public class MetricWriteHelper {
         return writer;
     }
 
+    /**
+     * This method is invoked once all the Tasks submitted to the TaskExecutionServiceProvider are done.
+     * Any sub tasks spawned by the tasks in the TaskExecutionServiceProvider needs to be synchronized such that the
+     * task completes its execution only after all its sub tasks are done.
+     * Tasks done by this method:
+     * -------------------------
+     * 1. Triggers the DerivedMetricsCalculator based on all the metrics published from all the tasks in a job
+     *    run.
+     * 2. Prints the total metrics published in the current job run.
+     * 3. Logs the total execution time from the time execute() method is triggered to the time "Metrics uploaded"
+     *    metric is published.
+     *
+     */
     public void onComplete() {
         int baseMetricsSize = 0;
         if (derivedMetricsCalculator != null) {
-            List<com.appdynamics.extensions.metrics.Metric> metricList = derivedMetricsCalculator.calculateAndReturnDerivedMetrics();
-            baseMetricsSize = metricsMap.size();
-            logger.debug("Total number of base metrics reported in this job run are : {}", baseMetricsSize);
-            transformAndPrintMetrics(metricList);
-            logger.debug("Total number of derived metrics reported in this job run are : {}", metricsMap.size() - baseMetricsSize);
-            derivedMetricsCalculator.clearBaseMetricsMap();
+            triggerDerivedMetrics();
         }
+        printMetricsUploaded();
+        logTime();
+    }
+
+    private void triggerDerivedMetrics() {
+        int baseMetricsSize;List<Metric> metricList = derivedMetricsCalculator.calculateAndReturnDerivedMetrics();
+        baseMetricsSize = metricsMap.size();
+        logger.debug("Total number of base metrics reported in this job run are : {}", baseMetricsSize);
+        transformAndPrintMetrics(metricList);
+        logger.debug("Total number of derived metrics reported in this job run are : {}", metricsMap.size() - baseMetricsSize);
+        derivedMetricsCalculator.clearBaseMetricsMap();
+    }
+
+    private void printMetricsUploaded() {
         printMetric(baseMonitor.getContextConfiguration().getMetricPrefix()+"|"+"Metrics Uploaded",
                 String.valueOf(metricsMap.size() + 1 ),"AVERAGE", "AVERAGE","COLLECTIVE" );
         logger.debug("Total number of metrics reported in this job run are : {}", metricsMap.size());
+    }
+
+    private void logTime() {
+        Long endTime = System.currentTimeMillis();
+        logger.info("Finished executing " + baseMonitor.getMonitorName() + " at " + TimeUtils.getFormattedTimestamp(endTime, "yyyy-MM-dd HH:mm:ss z"));
+        Long totalTime = endTime - startTime;
+        logger.info("Total time taken to execute " + baseMonitor.getMonitorName() + " : " + totalTime + " ms");
     }
 
     public boolean isCacheMetrics() {

--- a/src/main/java/com/appdynamics/extensions/util/TimeUtils.java
+++ b/src/main/java/com/appdynamics/extensions/util/TimeUtils.java
@@ -1,0 +1,25 @@
+package com.appdynamics.extensions.util;
+
+import com.appdynamics.extensions.ABaseMonitor;
+import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
+import org.slf4j.Logger;
+
+import java.text.SimpleDateFormat;
+
+/**
+ * Created by venkata.konala on 9/6/18.
+ */
+public class TimeUtils {
+
+    private static final Logger logger = ExtensionsLoggerFactory.getLogger(TimeUtils.class);
+
+    public static String getFormattedTimestamp(Long timeInMilli, String pattern) {
+        try {
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+            return simpleDateFormat.format(timeInMilli);
+        } catch (Exception e) {
+            logger.error("The time " + timeInMilli + " cannot be formatted to the pattern " + pattern);
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/appdynamics/extensions/MetricWriteHelperTest.java
+++ b/src/test/java/com/appdynamics/extensions/MetricWriteHelperTest.java
@@ -19,14 +19,24 @@ package com.appdynamics.extensions;
 import com.appdynamics.extensions.conf.MonitorContext;
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.conf.modules.DerivedMetricsModule;
+import com.appdynamics.extensions.conf.modules.MonitorExecutorServiceModule;
+import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
 import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.metrics.derived.DerivedMetricsCalculator;
 import com.appdynamics.extensions.yml.YmlReader;
 import com.google.common.collect.Lists;
 import com.singularity.ee.agent.systemagent.api.MetricWriter;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.math.BigDecimal;
@@ -39,7 +49,6 @@ import static org.mockito.Mockito.*;
 /**
  * Created by venkata.konala on 10/31/17.
  */
-
 public class MetricWriteHelperTest {
 
     @Test

--- a/src/test/java/com/appdynamics/extensions/util/TimeUtilsTest.java
+++ b/src/test/java/com/appdynamics/extensions/util/TimeUtilsTest.java
@@ -1,0 +1,32 @@
+package com.appdynamics.extensions.util;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Created by venkata.konala on 10/7/18.
+ */
+public class TimeUtilsTest {
+
+    @Test
+    public void whenAppropriateTimeAndPatternThenReturnFormattedTime() {
+        Long timeInMillis = 1538962125642L;
+        String timeStamp = TimeUtils.getFormattedTimestamp(timeInMillis, "yyyy-MM-dd HH:mm:ss z");
+        Assert.assertTrue(timeStamp.equals("2018-10-07 18:28:45 PDT"));
+    }
+
+    @Test
+    public void whenTimeIsNullAndPatternIsAppropriateThenReturnNull() {
+        Long timeInMillis = null;
+        String timeStamp = TimeUtils.getFormattedTimestamp(timeInMillis, "yyyy-MM-dd HH:mm:ss z");
+        Assert.assertTrue(timeStamp == null);
+    }
+
+    @Test
+    public void whenTimeIsAppropriateAndPatternIsNullThenReturnNull() {
+        Long timeInMillis = 1538962125642L;
+        String timeStamp = TimeUtils.getFormattedTimestamp(timeInMillis, null);
+        Assert.assertTrue(timeStamp == null);
+    }
+}


### PR DESCRIPTION
1. Added logging for startTime, endTime and totalExecutionTime for a monitor job run.
2. Created TimeUtils with time formatting method.