### PR TITLE
replace Charmatcher#ASCII with Charset.newEncoder#canEncode to avoid …

### DIFF
--- a/src/main/java/com/appdynamics/extensions/metrics/MetricCharSequenceReplacer.java
+++ b/src/main/java/com/appdynamics/extensions/metrics/MetricCharSequenceReplacer.java
@@ -16,12 +16,12 @@
 package com.appdynamics.extensions.metrics;
 
 import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
-import com.google.common.base.CharMatcher;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -129,10 +129,10 @@ public class MetricCharSequenceReplacer {
             final String replaceWith = replacement.get(REPLACEMENT_VALUE);
             if (replace == null || replace.isEmpty()) {
                 logger.debug("Skipping entry. Value for replace cannot be null or empty string");
-            } else if (replaceWith == null || hasDelimiter(replaceWith) || !CharMatcher.ASCII.matchesAllOf(replaceWith)) {
-                    logger.debug("replaceWith {} is null or has delimiters (|:,) or non-ascii characters. " +
-                            "Defaulting replaceWith to empty string", replaceWith);
-                    replacementMap.put(replace, EMPTY_STRING);
+            } else if (replaceWith == null || hasDelimiter(replaceWith) || !StandardCharsets.US_ASCII.newEncoder().canEncode(replaceWith)) {
+                logger.debug("replaceWith {} is null or has delimiters (|:,) or non-ascii characters. " +
+                        "Defaulting replaceWith to empty string", replaceWith);
+                replacementMap.put(replace, EMPTY_STRING);
             } else {
                 replacementMap.put(replace, replaceWith);
             }

--- a/src/main/java/com/appdynamics/extensions/util/ValidationUtils.java
+++ b/src/main/java/com/appdynamics/extensions/util/ValidationUtils.java
@@ -16,11 +16,11 @@
 package com.appdynamics.extensions.util;
 
 import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.appdynamics.extensions.util.StringUtils.hasText;
@@ -64,8 +64,8 @@ public class ValidationUtils {
     }
 
     public static boolean isValidMetricPath(String metricPath) {
-        if (!metricPath.contains(",") && !metricPath.contains("||") && !metricPath.endsWith("|") && CharMatcher
-                .ASCII.matchesAllOf(metricPath) && isValidMetricPrefix(metricPath)) {
+        if (!metricPath.contains(",") && !metricPath.contains("||") && !metricPath.endsWith("|") &&
+                StandardCharsets.US_ASCII.newEncoder().canEncode(metricPath) && isValidMetricPrefix(metricPath)) {
             return true;
         }
         logger.debug("The metric path {} is invalid", metricPath);

--- a/src/test/java/com/appdynamics/extensions/util/ValidationUtilsTest.java
+++ b/src/test/java/com/appdynamics/extensions/util/ValidationUtilsTest.java
@@ -46,6 +46,7 @@ public class ValidationUtilsTest {
         Assert.assertTrue(ValidationUtils.isValidMetricPath("Server|Component:123|Custom Metrics|Redis Monitor|test"));
         Assert.assertFalse(ValidationUtils.isValidMetricPath("Server|Component:123|Custom Metrics|Redis Monitor|test|"));
         Assert.assertFalse(ValidationUtils.isValidMetricPath("Server|Component:123|Custom Metrics|Redis,Monitor|test"));
+        Assert.assertFalse(ValidationUtils.isValidMetricPath("Server|Component:123|Custom Metrics|Rédis,Monitor|test"));
         Assert.assertFalse(ValidationUtils.isValidMetricPath("Server|Component:123|Custom Metrics|Redis Monitor||test"));
     }
 


### PR DESCRIPTION
…guava lib dependency in workbench mode

- Newer version of machineagent have updated jar for (`lib/`) guava from v18 to v27.1, this breaks code in workbench since `Charmatcher#ASCII` field is no longer present in guava27.1
- Updated code to use `Charset.newEncoder#canEncode`