### PR TITLE
Update Apache Commons Lang3 from 3.8 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>com.appdynamics</groupId>
@@ -327,6 +327,17 @@
                 <enabled>false</enabled>
             </snapshots>
             <url>https://github.com/Appdynamics/maven-repo/raw/master/releases</url>
+        </repository>
+        <repository>
+            <id>central</id>
+            <name>Maven Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <scm>


### PR DESCRIPTION
Updating the apache commons lang3 to 3.8 to 3.18