### PR TITLE
Fix MonitorHealthCheckTest timing issue

### DIFF
--- a/src/test/java/com/appdynamics/extensions/checks/MonitorHealthCheckTest.java
+++ b/src/test/java/com/appdynamics/extensions/checks/MonitorHealthCheckTest.java
@@ -83,7 +83,7 @@ public class MonitorHealthCheckTest {
 
         monitorHealthCheck.run();
 
-        Thread.currentThread().sleep(4000);
+        Thread.currentThread().sleep(5000);
 
         Mockito.verify(spyTestCheck, Mockito.times(3)).check();
     }
@@ -107,7 +107,7 @@ public class MonitorHealthCheckTest {
 
             if (!shouldStop) {
                 i++;
-                if (i == 2) {
+                if (i == 4) {
                     shouldStop = true;
                 }
             }


### PR DESCRIPTION
- Increased sleep time from 4s to 5s to allow more scheduler executions
- Updated TestCheckAlways to stop after 4 iterations instead of 3
- This ensures the test has enough time to verify 3 method calls as expected