### PR TITLE
SIM-10705 - Third Party Library Upgrade 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.0</version>
+            <version>2.22.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -137,17 +137,17 @@
         <dependency>
             <groupId>org.eclipse.jetty.ee10</groupId>
             <artifactId>jetty-ee10-webapp</artifactId>
-            <version>12.1.0</version>
+            <version>12.1.12</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>12.1.0</version>
+            <version>12.1.12</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.ee10</groupId>
             <artifactId>jetty-ee10-servlet</artifactId>
-            <version>12.1.0</version>
+            <version>12.1.12</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/com/appdynamics/extensions/http/Http4ClientBuilderTest.java
+++ b/src/test/java/com/appdynamics/extensions/http/Http4ClientBuilderTest.java
@@ -82,7 +82,7 @@ public class Http4ClientBuilderTest {
         proxyProps.put("uri", PROXY_URI);
         HttpClientBuilder builder = Http4ClientBuilder.getBuilder(map);
         CloseableHttpClient client = builder.build();
-        HttpGet get = new HttpGet("https://www.google.com");
+        HttpGet get = new HttpGet("http://www.google.com");
         CloseableHttpResponse response = client.execute(get);
         Assert.assertEquals(407, response.getStatusLine().getStatusCode());
         response.close();
@@ -118,7 +118,7 @@ public class Http4ClientBuilderTest {
         proxyProps.put("password", PROXYPASSWORD + "1");
         HttpClientBuilder builder = Http4ClientBuilder.getBuilder(map);
         CloseableHttpClient client = builder.build();
-        HttpGet get = new HttpGet("https://www.google.com");
+        HttpGet get = new HttpGet("http://www.google.com");
         CloseableHttpResponse response = client.execute(get);
         Assert.assertEquals(407, response.getStatusLine().getStatusCode());
         response.close();

--- a/src/test/java/com/appdynamics/extensions/util/MockJettyServer.java
+++ b/src/test/java/com/appdynamics/extensions/util/MockJettyServer.java
@@ -209,24 +209,25 @@ public class MockJettyServer {
                 if (Strings.isNullOrEmpty(header)) {
                     response.setStatus(407);
                     response.getHeaders().add("Proxy-Authenticate", "Basic realm=\"proxy.com\"");
+                    response.write(true, ByteBuffer.allocate(0), callback);
                 } else {
                     String value = header.replace("Basic ", "");
                     String s = new String(Base64.decodeBase64(value));
                     if (s.equals("proxyuser:proxypassword")) {
                         ByteBuffer byteBuffer = ByteBuffer.allocate(1024);
                         byteBuffer.put("AuthSuccess".getBytes());
-                        response.write(true,byteBuffer,callback);
+                        response.write(true, byteBuffer, callback);
                     } else {
                         response.setStatus(407);
                         response.getHeaders().add("Proxy-Authenticate", "Basic realm=\"proxy.com\"");
+                        response.write(true, ByteBuffer.allocate(0), callback);
                     }
                 }
             } else {
                 ByteBuffer byteBuffer = ByteBuffer.allocate(1024);
                 byteBuffer.put("NoAuth".getBytes());
-                response.write(true,byteBuffer,callback);
+                response.write(true, byteBuffer, callback);
             }
-            callback.succeeded();
             return response.hasLastWrite();
         }
     }


### PR DESCRIPTION
 Summary:

 This PR fixes test failures in Http4ClientBuilderTest caused by improper Jetty callback handling in MockJettyServer, and upgrades test/compile dependencies to their latest stable versions.

  Changes:

  - MockJettyServer.java: Added missing response.write() calls for 407 proxy authentication responses to properly complete the Jetty callback lifecycle. Removed the duplicate callback.succeeded() call that was
  causing the callback to be invoked twice, resulting in test failures.
  - Http4ClientBuilderTest.java: Changed proxy test URLs from https to http to avoid SSL handshake issues during proxy authentication tests, which were unrelated to what the tests were validating.
  - pom.xml: Bumped dependency versions:
    - jackson-databind: 2.21.0 → 2.22.1
    - jetty-ee10-webapp: 12.1.0 → 12.1.12
    - jetty-server: 12.1.0 → 12.1.12
    - jetty-ee10-servlet: 12.1.0 → 12.1.12

  Testing:
  - Http4ClientBuilderTest proxy authentication tests pass with the corrected callback and URL changes.